### PR TITLE
rework logging setup & add support for logging to loggly

### DIFF
--- a/example.env
+++ b/example.env
@@ -31,3 +31,6 @@ VPC_ID=
 # id of series to recieve ingests in the absence of a zoom meeting -> series mapping
 # this is meant for testing/dev only
 DEFAULT_SERIES_ID=
+
+# send log events to loggly if set
+LOGGLY_TOKEN=

--- a/functions/common-requirements.txt
+++ b/functions/common-requirements.txt
@@ -1,3 +1,3 @@
-boto3
+aws-lambda-logging==0.0.23
+pyloggly==0.3.0
 requests
-aws-lambda-logging

--- a/functions/common.py
+++ b/functions/common.py
@@ -1,14 +1,48 @@
 
+import logging
 import aws_lambda_logging
 from os import getenv as env
+from pyloggly import LogglyBulkHandler
 
 LOG_LEVEL = env('DEBUG') and 'DEBUG' or 'INFO'
 BOTO_LOG_LEVEL = env('BOTO_DEBUG') and 'DEBUG' or 'INFO'
+LOGGLY_TOKEN = env('LOGGLY_TOKEN')
+LOGGLY_TAGS = env('LOGGLY_TAGS')
 
-def setup_logging(context):
-    aws_lambda_logging.setup(
-        level=LOG_LEVEL,
-        boto_level=BOTO_LOG_LEVEL,
-        aws_request_id=context.aws_request_id
-    )
+def setup_logging(handler_func):
+
+    def wrapped_func(event, context):
+
+        extra_info = {'aws_request_id': context.aws_request_id}
+        aws_lambda_logging.setup(
+            level=LOG_LEVEL,
+            boto_level=BOTO_LOG_LEVEL,
+            **extra_info
+        )
+
+        # do this second otherwise aws_lambda_logging clobbers our formatter
+        if LOGGLY_TOKEN:
+            tags = LOGGLY_TAGS and ",".join(LOGGLY_TAGS.split()) or None
+            logger = logging.getLogger()
+            loggly_handler = LogglyBulkHandler(LOGGLY_TOKEN, 'logs-01.loggly.com', tags)
+            loggly_handler.level = logging.getLevelName(LOG_LEVEL)
+            logger.addHandler(loggly_handler)
+            logger.debug("Logging to loggly!")
+        else:
+            loggly_handler = None
+
+        # now call the handler
+        try:
+            retval = handler_func(event, context)
+        except Exception as e:
+            logger.exception("handler failed!")
+            raise
+        finally:
+            if loggly_handler:
+                loggly_handler.flush()
+
+        return retval
+
+    wrapped_func.__name__ = handler_func.__name__
+    return wrapped_func
 

--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -1,6 +1,6 @@
-import requests
 import boto3
 import json
+import requests
 from os import getenv as env
 from bs4 import BeautifulSoup
 from bs4 import SoupStrainer
@@ -28,12 +28,13 @@ class FileNameNotFound(Exception):
     pass
 
 
+@setup_logging
 def handler(event, context):
     """
     This function receives an event on each new entry in the download urls
     DyanmoDB table
     """
-    setup_logging(context)
+    logger.debug("downloader invoked!")
     logger.info(event)
 
     download_queue = sqs.get_queue_by_name(QueueName=DOWNLOAD_QUEUE_NAME)

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -43,9 +43,10 @@ def oc_api_request(method, endpoint, **kwargs):
     return resp
 
 
+@setup_logging
 def handler(event, context):
 
-    setup_logging(context)
+    logger.debug("uploader invoked!")
     logger.info(event)
 
     # allow upload count to be overridden

--- a/functions/zoom-webhook.py
+++ b/functions/zoom-webhook.py
@@ -1,12 +1,11 @@
-import requests
 import boto3
 import jwt
 import time
 import json
+import requests
 from datetime import datetime
 from urllib.parse import parse_qsl
 from os import getenv as env
-from botocore.exceptions import ClientError
 
 import logging
 from common import setup_logging
@@ -59,6 +58,7 @@ def resp_400(msg):
     }
 
 
+@setup_logging
 def handler(event, context):
     """
     This function accepts the incoming POST relay from the API Gateway endpoint that
@@ -66,7 +66,7 @@ def handler(event, context):
     the actual download url so we have to fetch that in a Zoom api call.
     """
 
-    setup_logging(context)
+    logger.debug("webhook invoked!")
     logger.info(event)
 
     if 'body' not in event:
@@ -268,5 +268,4 @@ def send_sqs_message(record):
         raise
 
     logger.debug({"Message sent": message_sent})
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,11 @@ pytest-env
 pytest-mock
 moto
 tox
+boto3
+requests
 requests-mock
 
+-r functions/common-requirements.txt
 -r functions/zoom-webhook.txt
 -r functions/zoom-downloader.txt
 -r functions/zoom-uploader.txt

--- a/tasks.py
+++ b/tasks.py
@@ -275,6 +275,7 @@ def __create_or_update(ctx, op):
         lambda_objects[func] = func_code
 
     subnet_id, sg_id = vpc_components(ctx)
+    loggly_token = getenv("LOGGLY_TOKEN", False) or ""
 
     cmd = ("aws {} cloudformation {}-stack {} "
            "--capabilities CAPABILITY_NAMED_IAM --stack-name {} "
@@ -294,6 +295,7 @@ def __create_or_update(ctx, op):
            "ParameterKey=DefaultOpencastSeriesId,ParameterValue='{}' "
            "ParameterKey=VpcSecurityGroupId,ParameterValue='{}' "
            "ParameterKey=VpcSubnetId,ParameterValue='{}' "
+           "ParameterKey=LogglyToken,ParameterValue='{}' "
            ).format(
                 profile_arg(),
                 op,
@@ -313,7 +315,8 @@ def __create_or_update(ctx, op):
                 getenv("OPENCAST_API_PASSWORD"),
                 getenv("DEFAULT_SERIES_ID", False),
                 sg_id,
-                subnet_id
+                subnet_id,
+                loggly_token
                 )
     print(cmd)
     ctx.run(cmd)

--- a/template.yml
+++ b/template.yml
@@ -31,6 +31,8 @@ Parameters:
     Type: String
   VpcSubnetId:
     Type: String
+  LogglyToken:
+    Type: String
 
 Conditions:
   UploadFunctionVpcConfig: !Not [!Equals ["", !Ref VpcSubnetId]]
@@ -160,6 +162,8 @@ Resources:
           ZOOM_API_KEY: !Ref ZoomApiKey
           ZOOM_API_SECRET: !Ref ZoomApiSecret
           DEBUG: 0
+          LOGGLY_TOKEN: !Ref LogglyToken
+          LOGGLY_TAGS: !Join [" ", [!Sub "${AWS::StackName}", "zoom-webhook zoom-ingester"]]
       Code:
         S3Bucket: !Select [0, !Split ["/", !Ref WebhookLambdaCode]]
         S3Key: !Select [1, !Split ["/", !Ref WebhookLambdaCode]]
@@ -211,6 +215,8 @@ Resources:
           DOWNLOAD_QUEUE_NAME: !GetAtt [ZoomIngesterDownloaderQueue, QueueName]
           UPLOAD_QUEUE_NAME: !GetAtt [ZoomIngesterUploadQueue, QueueName]
           DEBUG: 0
+          LOGGLY_TOKEN: !Ref LogglyToken
+          LOGGLY_TAGS: !Join [" ", [!Sub "${AWS::StackName}", "zoom-downloader zoom-ingester"]]
       Code:
         S3Bucket: !Select [0, !Split ["/", !Ref ZoomDownloaderLambdaCode]]
         S3Key: !Select [1, !Split ["/", !Ref ZoomDownloaderLambdaCode]]
@@ -250,6 +256,8 @@ Resources:
           OPENCAST_API_PASSWORD: !Ref OpencastApiPassword
           DEFAULT_SERIES_ID: !Ref DefaultOpencastSeriesId
           DEBUG: 0
+          LOGGLY_TOKEN: !Ref LogglyToken
+          LOGGLY_TAGS: !Join [" ", [!Sub "${AWS::StackName}", "zoom-uploader zoom-ingester"]]
       Code:
         S3Bucket: !Select [0, !Split ["/", !Ref ZoomUploaderLambdaCode]]
         S3Key: !Select [1, !Split ["/", !Ref ZoomUploaderLambdaCode]]


### PR DESCRIPTION
The main thing here is incorporating a Loggly log handler. Loggly has an easier alarm notification system than cloudwatch, plus some chart dashboard features we can explore.

To get this to work properly I had to dig into [pyloggly](https://github.com/harvard-dce/pyloggly) and update some stuff, including making it py3 compatible and adding a new type of handler.

A secondary effect of this was to make the logging setup a decorator that wraps the main handler. This was the only way to ensure that all pending log events got flushed to loggly when the lambda function ends or raises an error.