### PR TITLE
Uploader changes - don't merge

### DIFF
--- a/example.env
+++ b/example.env
@@ -41,6 +41,11 @@ DEFAULT_SERIES_ID=
 # NOTIFICATIONS_EMAIL address
 DEFAULT_PRODUCER_EMAIL=
 
+# These settings will override the Opencast lookup of producer and producer email
+# for a series.
+OVERRIDE_PRODUCER=
+OVERRIDE_PRODUCER_EMAIL=
+
 # Python pytz timezone
 LOCAL_TIME_ZONE=US/Eastern
 

--- a/example.env
+++ b/example.env
@@ -35,6 +35,12 @@ VPC_ID=
 # be ingested into that default series id.
 DEFAULT_SERIES_ID=
 
+# When the producer email of a series cannot be determined via an
+# /otherpubs/epidodedefault lookup, the Opencast workflow notifications will go
+# to this address. If this is left empty the notifications will go to the
+# NOTIFICATIONS_EMAIL address
+DEFAULT_PRODUCER_EMAIL=
+
 # Python pytz timezone
 LOCAL_TIME_ZONE=US/Eastern
 

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -23,6 +23,8 @@ ZOOM_RECORDING_TYPE_NUM = 'S1'
 ZOOM_OPENCAST_WORKFLOW = "DCE-production-zoom"
 DEFAULT_SERIES_ID = env("DEFAULT_SERIES_ID")
 DEFAULT_PRODUCER_EMAIL = env("DEFAULT_PRODUCER_EMAIL")
+OVERRIDE_PRODUCER = env("OVERRIDE_PRODUCER")
+OVERRIDE_PRODUCER_EMAIL = env("OVERRIDE_PRODUCER_EMAIL")
 CLASS_SCHEDULE_TABLE = env("CLASS_SCHEDULE_TABLE")
 LOCAL_TIME_ZONE = env("LOCAL_TIME_ZONE")
 
@@ -213,14 +215,18 @@ class Upload:
 
     @property
     def producer_email(self):
-        if 'publisher' in self.episode_defaults:
+        if OVERRIDE_PRODUCER_EMAIL:
+            return OVERRIDE_PRODUCER_EMAIL
+        elif 'publisher' in self.episode_defaults:
             return self.episode_defaults['publisher']
         elif DEFAULT_PRODUCER_EMAIL:
             return DEFAULT_PRODUCER_EMAIL
 
     @property
     def producer(self):
-        if 'contributor' in self.episode_defaults:
+        if OVERRIDE_PRODUCER:
+            return OVERRIDE_PRODUCER
+        elif 'contributor' in self.episode_defaults:
             return self.episode_defaults['contributor']
         else:
             return "Zoom Ingester"

--- a/tasks.py
+++ b/tasks.py
@@ -578,6 +578,8 @@ def __create_or_update(ctx, op):
            "ParameterKey=OpencastApiPassword,ParameterValue='{}' "
            "ParameterKey=DefaultOpencastSeriesId,ParameterValue='{}' "
            "ParameterKey=DefaultProducerEmail,ParameterValue='{}' "
+           "ParameterKey=OverrideProducer,ParameterValue='{}' "
+           "ParameterKey=OverrideProducerEmail,ParameterValue='{}' "
            "ParameterKey=LocalTimeZone,ParameterValue='{}' "
            "ParameterKey=VpcSecurityGroupId,ParameterValue='{}' "
            "ParameterKey=VpcSubnetId,ParameterValue='{}' "
@@ -601,6 +603,8 @@ def __create_or_update(ctx, op):
                 getenv("OPENCAST_API_PASSWORD"),
                 getenv("DEFAULT_SERIES_ID", required=False) or "",
                 default_producer_email,
+                getenv("OVERRIDE_PRODUCER", required=False) or "",
+                getenv("OVERRIDE_PRODUCER_EMAIL", required=False) or "",
                 getenv("LOCAL_TIME_ZONE"),
                 sg_id,
                 subnet_id,

--- a/tasks.py
+++ b/tasks.py
@@ -558,6 +558,10 @@ def __create_or_update(ctx, op):
 
     subnet_id, sg_id = vpc_components(ctx)
 
+    default_producer_email = getenv('DEFAULT_PRODUCER_EMAIL', required=False)
+    if default_producer_email is None:
+        default_producer_email = getenv('NOTIFICATION_EMAIL')
+
     cmd = ("aws {} cloudformation {}-stack {} "
            "--capabilities CAPABILITY_NAMED_IAM --stack-name {} "
            "--template-body file://{} "
@@ -573,6 +577,7 @@ def __create_or_update(ctx, op):
            "ParameterKey=OpencastApiUser,ParameterValue='{}' "
            "ParameterKey=OpencastApiPassword,ParameterValue='{}' "
            "ParameterKey=DefaultOpencastSeriesId,ParameterValue='{}' "
+           "ParameterKey=DefaultProducerEmail,ParameterValue='{}' "
            "ParameterKey=LocalTimeZone,ParameterValue='{}' "
            "ParameterKey=VpcSecurityGroupId,ParameterValue='{}' "
            "ParameterKey=VpcSubnetId,ParameterValue='{}' "
@@ -594,7 +599,8 @@ def __create_or_update(ctx, op):
                 getenv("OPENCAST_BASE_URL"),
                 getenv("OPENCAST_API_USER"),
                 getenv("OPENCAST_API_PASSWORD"),
-                getenv("DEFAULT_SERIES_ID", False),
+                getenv("DEFAULT_SERIES_ID", required=False) or "",
+                default_producer_email,
                 getenv("LOCAL_TIME_ZONE"),
                 sg_id,
                 subnet_id,

--- a/template.yml
+++ b/template.yml
@@ -28,6 +28,12 @@ Parameters:
   DefaultProducerEmail:
     Type: String
     Default: "${AWS::NoValue}"
+  OverrideProducer:
+    Type: String
+    Default: "${AWS::NoValue}"
+  OverrideProducerEmail:
+    Type: String
+    Default: "${AWS::NoValue}"
   LocalTimeZone:
     Type: String
     Default: 'US/Eastern'
@@ -339,6 +345,8 @@ Resources:
           OPENCAST_API_PASSWORD: !Ref OpencastApiPassword
           DEFAULT_SERIES_ID: !Ref DefaultOpencastSeriesId
           DEFAULT_PRODUCER_EMAIL: !Ref DefaultProducerEmail
+          OVERRIDE_PRODUCER: !Ref OverrideProducer
+          OVERRIDE_PRODUCER_EMAIL: !Ref OverrideProducerEmail
           CLASS_SCHEDULE_TABLE: !Ref ClassScheduleDynamoTable
           LOCAL_TIME_ZONE: !Ref LocalTimeZone
           DEBUG: 0

--- a/template.yml
+++ b/template.yml
@@ -25,6 +25,9 @@ Parameters:
   DefaultOpencastSeriesId:
     Type: String
     Default: "${AWS::NoValue}"
+  DefaultProducerEmail:
+    Type: String
+    Default: "${AWS::NoValue}"
   LocalTimeZone:
     Type: String
     Default: 'US/Eastern'
@@ -335,6 +338,7 @@ Resources:
           OPENCAST_API_USER: !Ref OpencastApiUser
           OPENCAST_API_PASSWORD: !Ref OpencastApiPassword
           DEFAULT_SERIES_ID: !Ref DefaultOpencastSeriesId
+          DEFAULT_PRODUCER_EMAIL: !Ref DefaultProducerEmail
           CLASS_SCHEDULE_TABLE: !Ref ClassScheduleDynamoTable
           LOCAL_TIME_ZONE: !Ref LocalTimeZone
           DEBUG: 0


### PR DESCRIPTION
This comes out of a few requirement changes from a meeting last week.

- For the summer term the videos will not be shown to students, so the workflow has been updated to include a test local step
- The test local notifications need to go to the appropriate producer, so now we do an opencast api call to get the correct email/name. This needed to happen eventually anyway.
- **but** at least for the beginning of the summer term all notifications will go to Kriss, so we needed a way to override the previous bullet point's behavior.

Something is still not right with this as I'm getting an error about the upload.producer_email value being 'None' when it tries to assemble the episode xml. Ran into issues due to uploader queue messages not being visible (although sqs tells me they're there).