### PR TITLE
Schedule matching fix, Optional cloudformation parameters

### DIFF
--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -119,7 +119,8 @@ def handler(event, context):
             "host_name": host_data['host_name'],
             "host_id": message_body['host_id'],
             "topic": recording_data['topic'],
-            "start_time": recording_data['start_time'],
+            "meeting_start_time": recording_data['start_time'],
+            "recording_start_time": recording_data['recording_files'][0]['recording_start'],
             "recording_count": recording_data['recording_count'],
             "webhook_received_time": message_body['received_time'],
             "correlation_id": message_body['correlation_id']

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -106,7 +106,9 @@ class Upload:
 
     @property
     def created(self):
-        utc = datetime.strptime(self.data['start_time'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone('UTC'))
+        utc = datetime.strptime(
+                self.data['recording_start_time'], '%Y-%m-%dT%H:%M:%SZ')\
+                .replace(tzinfo=timezone('UTC'))
         return utc
 
     @property
@@ -143,7 +145,6 @@ class Upload:
     @property
     def override_series_id(self):
         return self.data.get('override_series_id')
-
 
     def series_id_from_schedule(self):
 
@@ -197,9 +198,9 @@ class Upload:
                 logger.info("Using override series id '{}'".format(series_id))
             else:
                 series_id = self.series_id_from_schedule()
-                logger.info("Matched with opencast series '{}'!".format(series_id))
 
             if series_id is not None:
+                logger.info("Matched with opencast series '{}'!".format(series_id))
                 self._oc_series_id = series_id
             elif DEFAULT_SERIES_ID is not None and DEFAULT_SERIES_ID != "None":
                 logger.info("Using default series id {}".format(DEFAULT_SERIES_ID))
@@ -216,7 +217,7 @@ class Upload:
 
     @property
     def producer_email(self):
-        if OVERRIDE_PRODUCER_EMAIL:
+        if OVERRIDE_PRODUCER_EMAIL and OVERRIDE_PRODUCER_EMAIL != "None":
             return OVERRIDE_PRODUCER_EMAIL
         elif 'publisher' in self.episode_defaults:
             return self.episode_defaults['publisher']
@@ -225,7 +226,7 @@ class Upload:
 
     @property
     def producer(self):
-        if OVERRIDE_PRODUCER:
+        if OVERRIDE_PRODUCER and OVERRIDE_PRODUCER != "None":
             return OVERRIDE_PRODUCER
         elif 'contributor' in self.episode_defaults:
             return self.episode_defaults['contributor']

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -176,7 +176,7 @@ class Upload:
                         zoom_time.replace(hour=scheduled_time.hour, minute=scheduled_time.minute)
                         ).total_seconds()
 
-        threshold_minutes = 20
+        threshold_minutes = 30
         if timedelta < (threshold_minutes * 60):
             return schedule['opencast_series_id']
         else:

--- a/tasks.py
+++ b/tasks.py
@@ -606,16 +606,17 @@ def __create_or_update(ctx, op):
                 getenv("OPENCAST_BASE_URL"),
                 getenv("OPENCAST_API_USER"),
                 getenv("OPENCAST_API_PASSWORD"),
-                getenv("DEFAULT_SERIES_ID", required=False) or "",
+                getenv("DEFAULT_SERIES_ID", required=False),
                 default_producer_email,
-                getenv("OVERRIDE_PRODUCER", required=False) or "",
-                getenv("OVERRIDE_PRODUCER_EMAIL", required=False) or "",
+                getenv("OVERRIDE_PRODUCER", required=False),
+                getenv("OVERRIDE_PRODUCER_EMAIL", required=False),
                 getenv("LOCAL_TIME_ZONE"),
                 sg_id,
                 subnet_id,
                 getenv("LAMBDA_RELEASE_ALIAS"),
-                getenv("LOG_NOTIFICATIONS_FILTER_LOG_LEVEL", required=False) or ""
+                getenv("LOG_NOTIFICATIONS_FILTER_LOG_LEVEL", required=False)
                 )
+
     res = ctx.run(cmd)
 
     if res.exited == 0:


### PR DESCRIPTION
Match schedule based on recording start time rather than meeting start time. Increase threshold (20 minutes to 30 minutes.) Short term fix for optional CloudFormation parameters: check for "None" value and don't replace unset variables with "".