### PR TITLE
concat bug fix

### DIFF
--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -236,8 +236,7 @@ def next_track_sequence(prev_file, file):
 
 def stream_file_to_s3(file, uuid, track_sequence):
 
-    metadata = {'uuid': uuid,
-                'track_sequence': str(track_sequence)}
+    metadata = {'uuid': uuid}
 
     if file['file_type'].lower() in ["mp4", "m4a", "chat"]:
         stream, zoom_name = get_connection_using_play_url(file['play_url'])
@@ -250,7 +249,9 @@ def stream_file_to_s3(file, uuid, track_sequence):
         stream, zoom_name = get_connection_using_download_url(file['download_url'])
 
     metadata['file_type'] = zoom_name.split('.')[-1]
-    filename = create_filename(file['id'], file['meeting_id'], zoom_name)
+    filename = create_filename("{:03d}-{}".format(track_sequence, file['id']),
+                               file['meeting_id'],
+                               zoom_name)
 
     logger.info("Beginning upload of {}".format(filename))
     part_info = {'Parts': []}

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -341,16 +341,10 @@ class Upload:
 
         logger.info("Adding tracks")
 
-        def sorted_videos(vids):
-            return sorted(
-                    vids,
-                    key=lambda vid: vid.metadata['track_sequence']
-                   )
-
         if self.speaker_videos is not None:
-            videos = sorted_videos(self.speaker_videos)
+            videos = self.speaker_videos
         elif self.gallery_videos is not None:
-            videos = sorted_videos(self.gallery_videos)
+            videos = self.gallery_videos
         else:
             raise Exception("No mp4 files available for upload.")
 


### PR DESCRIPTION
opencast concatenates files in alphabetical order
prepend track sequence number to file name in s3 bucket to ensure correct ordering
new file naming format: {md5 of uuid}/{track number}-{file id}.{file type}