### PR TITLE
Double url encode uuid beginning with /

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -331,7 +331,10 @@ def exec_webhook(ctx, uuid, host_id, status=None, webhook_version=3):
     print("Returned with status code: {}. {}".format(resp['status'], resp['body']))
 
 
-@task
+@task(help={
+    'series_id': 'override normal opencast series id lookup',
+    'ignore_schedule': 'do opencast series id lookup but ignore if meeting times don\'t match'
+})
 def exec_downloader(ctx, series_id=None, ignore_schedule=False, qualifier=None):
     """
     Manually trigger downloader.
@@ -361,10 +364,7 @@ def exec_downloader(ctx, series_id=None, ignore_schedule=False, qualifier=None):
     return res
 
 
-@task(help={
-    'series_id': 'override normal opencast series id lookup',
-    'ignore_schedule': 'do opencast series id lookup but ignore if meeting times don\'t match'
-})
+@task
 def exec_uploader(ctx, qualifier=None):
     """
     Manually trigger uploader.

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -136,7 +136,7 @@ def test_recording_data(mocker):
     mocker.patch.object(downloader, 'remove_incomplete_metadata')
     mocker.patch.object(downloader, 'verify_recording_status')
     calls = [('tCh9CNwpQ4xfRJmPpyWQ==', 'https://api.zoom.us/v2/meetings/tCh9CNwpQ4xfRJmPpyWQ==/recordings'),
-             ('/Ch9CNwpQ4xfRJmPpyWQ9/', 'https://api.zoom.us/v2/meetings//Ch9CNwpQ4xfRJmPpyWQ9//recordings')]
+             ('/Ch9CNwpQ4xfRJmPpyWQ9/', 'https://api.zoom.us/v2/meetings/%252FCh9CNwpQ4xfRJmPpyWQ9%252F/recordings')]
 
     for call in calls:
 


### PR DESCRIPTION
Zoom plans to remove url unsafe characters from their uuids which we need to pass into Zoom API requests as path parameters. In the meantime, any recording that happens to have this character in its uuid cannot be processed without double url encoding the uuid when passing it as a path parameter to any Zoom API endpoint.