### PR TITLE
fix the way ignore schedule works and rewrite unit tests

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -237,8 +237,8 @@ def list_recordings(ctx, date=str(datetime.date.today())):
 
 
 @task(help={'uuid': 'meeting instance uuid',
-            'ignore_schedule': ('ignore schedule, use default series if '
-                                'available'),
+            'ignore_schedule': ('do opencast series id lookup but ignore if '
+                                'meeting times don\'t match'),
             'override_series_id': ('opencast series id to use regardless of '
                                    'schedule')})
 def exec_pipeline(ctx, uuid, ignore_schedule=False, override_series_id=None):


### PR DESCRIPTION
I realized a that we must have had a misunderstanding about how ignore schedule works a long time ago!
This change fixes ignore schedule so that it matches with the opencast series even if the times don't match (but doesn't ignore the zoom series id -> opencast series id mapping)