### PR TITLE
calculate estimated zoom processing time

### DIFF
--- a/functions/zoom-webhook.py
+++ b/functions/zoom-webhook.py
@@ -88,16 +88,11 @@ def handler(event, context):
         resp_callback = INGEST_EVENT_TYPES[zoom_event]
         return resp_callback(str(e))
 
-    sqs_message = construct_sqs_message(payload, context)
+    sqs_message = construct_sqs_message(payload, context, zoom_event)
     logger.info({"sqs_message": sqs_message})
 
-    if "delay_seconds" in payload:
-        logger.debug("Override default message delay.")
-        send_sqs_message(sqs_message, delay=payload["delay_seconds"])
-    elif zoom_event == "on.demand.ingest":
-        send_sqs_message(sqs_message, delay=0)
-    else:
-        send_sqs_message(sqs_message)
+    delay = 0 if zoom_event == "on.demand.ingest" else DEFAULT_MESSAGE_DELAY
+    send_sqs_message(sqs_message, delay=delay)
 
     return {
         "statusCode": 200,
@@ -171,7 +166,7 @@ def validate_payload(payload):
         raise BadWebhookData("Unrecognized payload format. {}".format(e))
 
 
-def construct_sqs_message(payload, context):
+def construct_sqs_message(payload, context, zoom_event):
     now = datetime.strftime(
                 timezone(LOCAL_TIME_ZONE).localize(datetime.today()),
                 TIMESTAMP_FORMAT)
@@ -202,10 +197,11 @@ def construct_sqs_message(payload, context):
 
     if "on_demand_series_id" in payload:
         sqs_message["on_demand_series_id"] = payload["on_demand_series_id"]
-    else:
+
+    if zoom_event == "recording.completed":
         zoom_processing_mins = estimated_processing_mins(
-            payload["object"]["start_time"],
-            payload["object"]["duration"]
+            sqs_message["start_time"],
+            sqs_message["duration"]
         )
         sqs_message["zoom_processing_minutes"] = zoom_processing_mins
 
@@ -220,7 +216,6 @@ def estimated_processing_mins(start_ts, duration_in_minutes):
 
 
 def send_sqs_message(message, delay=DEFAULT_MESSAGE_DELAY):
-
     logger.debug("SQS sending start...")
     sqs = boto3.resource("sqs")
 

--- a/functions/zoom-webhook.py
+++ b/functions/zoom-webhook.py
@@ -91,8 +91,11 @@ def handler(event, context):
     sqs_message = construct_sqs_message(payload, context, zoom_event)
     logger.info({"sqs_message": sqs_message})
 
-    delay = 0 if zoom_event == "on.demand.ingest" else DEFAULT_MESSAGE_DELAY
-    send_sqs_message(sqs_message, delay=delay)
+    if zoom_event == "on.demand.ingest":
+        delay = 0
+    else:
+        delay = DEFAULT_MESSAGE_DELAY
+    send_sqs_message(sqs_message, delay)
 
     return {
         "statusCode": 200,
@@ -215,7 +218,7 @@ def estimated_processing_mins(start_ts, duration_in_minutes):
     return processing_time.total_seconds() // 60
 
 
-def send_sqs_message(message, delay=DEFAULT_MESSAGE_DELAY):
+def send_sqs_message(message, delay):
     logger.debug("SQS sending start...")
     sqs = boto3.resource("sqs")
 

--- a/functions/zoom-webhook.py
+++ b/functions/zoom-webhook.py
@@ -207,7 +207,7 @@ def construct_sqs_message(payload, context):
             payload["object"]["start_time"],
             payload["object"]["duration"]
         )
-        sqs_message["zoom_processing_time"] = zoom_processing_mins
+        sqs_message["zoom_processing_minutes"] = zoom_processing_mins
 
     return sqs_message
 

--- a/tasks.py
+++ b/tasks.py
@@ -396,8 +396,7 @@ def exec_webhook(ctx, uuid, on_demand_series_id=None):
             "event": "on.demand.ingest",
             "payload": {
                 "on_demand_series_id": on_demand_series_id.strip(),
-                "object": data,
-                "delay_seconds": 0
+                "object": data
             }
         }
     else:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -117,9 +117,14 @@ def test_handler_happy_trail(handler, mocker, webhook_payload,
     mock_sqs_send = mocker.patch.object(webhook, 'send_sqs_message')
 
     resp = handler(webhook, event)
-    expected_msg = sqs_message_from_webhook_payload(FROZEN_TIME)
-    mock_sqs_send.assert_called_once_with(expected_msg)
+    expected_msg = sqs_message_from_webhook_payload(
+        FROZEN_TIME, "recording.completed"
+    )
+    mock_sqs_send.assert_called_once_with(
+        expected_msg, delay=webhook.DEFAULT_MESSAGE_DELAY
+    )
     assert resp['statusCode'] == 200
+
 
 @freeze_time(FROZEN_TIME)
 def test_no_mp4s_response(handler, mocker, webhook_payload):
@@ -138,23 +143,6 @@ def test_no_mp4s_response(handler, mocker, webhook_payload):
     resp = handler(webhook, event)
     assert resp["statusCode"] == 400
 
-@freeze_time(FROZEN_TIME)
-def test_delay_seconds(handler, mocker, webhook_payload,
-                       sqs_message_from_webhook_payload):
-    delay_seconds = 5
-    payload = webhook_payload()
-    payload["payload"]["delay_seconds"] = delay_seconds
-    event = {
-        "body": json.dumps(payload)
-    }
-    mock_sqs_send = mocker.patch.object(webhook, 'send_sqs_message')
-
-    resp = handler(webhook, event)
-    expected_msg = sqs_message_from_webhook_payload(FROZEN_TIME)
-    mock_sqs_send.assert_called_once_with(
-        expected_msg, delay=delay_seconds)
-    assert resp['statusCode'] == 200
-
 
 @freeze_time(FROZEN_TIME)
 def test_on_demand_no_delay(handler, mocker, webhook_payload,
@@ -167,8 +155,7 @@ def test_on_demand_no_delay(handler, mocker, webhook_payload,
     mock_sqs_send = mocker.patch.object(webhook, 'send_sqs_message')
 
     resp = handler(webhook, event)
-    expected_msg = sqs_message_from_webhook_payload(FROZEN_TIME)
-    mock_sqs_send.assert_called_once_with(
-        expected_msg, delay=0)
+    expected_msg = sqs_message_from_webhook_payload(FROZEN_TIME, payload["event"])
+    mock_sqs_send.assert_called_once_with(expected_msg, delay=0)
     assert resp['statusCode'] == 200
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -121,7 +121,7 @@ def test_handler_happy_trail(handler, mocker, webhook_payload,
         FROZEN_TIME, "recording.completed"
     )
     mock_sqs_send.assert_called_once_with(
-        expected_msg, delay=webhook.DEFAULT_MESSAGE_DELAY
+        expected_msg, webhook.DEFAULT_MESSAGE_DELAY
     )
     assert resp['statusCode'] == 200
 
@@ -156,6 +156,6 @@ def test_on_demand_no_delay(handler, mocker, webhook_payload,
 
     resp = handler(webhook, event)
     expected_msg = sqs_message_from_webhook_payload(FROZEN_TIME, payload["event"])
-    mock_sqs_send.assert_called_once_with(expected_msg, delay=0)
+    mock_sqs_send.assert_called_once_with(expected_msg, 0)
     assert resp['statusCode'] == 200
 


### PR DESCRIPTION
Calculate estimated Zoom processing time by using the start_time and duration from the webhook notification along with the time that the webhook notification was received. Do this only for notifications coming from Zoom (not for on demand ingests), and log this information so that it can be graphed in the dashboard.