### PR TITLE
multithreaded multipart transfer to s3

### DIFF
--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -9,6 +9,7 @@ from pytz import timezone
 from datetime import datetime
 from collections import OrderedDict
 import logging
+import concurrent.futures
 
 logger = logging.getLogger()
 
@@ -552,8 +553,17 @@ class ZoomFile:
     def file_extension(self):
         return Path(self.zoom_filename).suffix[1:]
 
+    def upload_part(self, part_number, chunk):
+        part = self.s3.upload_part(Body=chunk,
+                              Bucket=ZOOM_VIDEOS_BUCKET,
+                              Key=self.s3_filename,
+                              PartNumber=part_number,
+                              UploadId=self.upload_id)
+
+        return part
+
     def stream_file_to_s3(self):
-        s3 = boto3.client("s3")
+        self.s3 = boto3.client("s3")
 
         metadata = {
             "uuid": self.file_data["meeting_uuid"],
@@ -565,41 +575,52 @@ class ZoomFile:
             {"uploading file to S3": self.s3_filename,
              "metadata": metadata}
         )
-        part_info = {"Parts": []}
-        mpu = s3.create_multipart_upload(
+        parts = []
+        mpu = self.s3.create_multipart_upload(
                     Bucket=ZOOM_VIDEOS_BUCKET,
                     Key=self.s3_filename,
                     Metadata=metadata)
+        self.upload_id = mpu["UploadId"]
 
         try:
             chunks = enumerate(
                         self.stream.iter_content(chunk_size=MIN_CHUNK_SIZE), 1
                      )
-            for part_number, chunk in chunks:
-                part = s3.upload_part(Body=chunk,
-                                      Bucket=ZOOM_VIDEOS_BUCKET,
-                                      Key=self.s3_filename,
-                                      PartNumber=part_number,
-                                      UploadId=mpu["UploadId"])
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future_map = {}
+                for part_number, chunk in chunks:
+                    f = executor.submit(self.upload_part, part_number, chunk)
+                    future_map[f] = part_number
+                
+                for future in concurrent.futures.as_completed(future_map):
+                    part_number = future_map[future]
+                    part = future.result()
+                    parts.append({
+                        "PartNumber": part_number,
+                        "ETag": part["ETag"]
+                    })
 
-                part_info["Parts"].append({
-                    "PartNumber": part_number,
-                    "ETag": part["ETag"]
-                })
+            # complete_multipart_upload requires parts in order by part number
+            parts = sorted(parts, key=lambda i: i["PartNumber"])
 
-            s3.complete_multipart_upload(Bucket=ZOOM_VIDEOS_BUCKET,
-                                         Key=self.s3_filename,
-                                         UploadId=mpu["UploadId"],
-                                         MultipartUpload=part_info)
+            self.s3.complete_multipart_upload(
+                Bucket=ZOOM_VIDEOS_BUCKET,
+                Key=self.s3_filename,
+                UploadId=mpu["UploadId"],
+                MultipartUpload={"Parts": parts}
+            )
             print("Completed multipart upload of {}.".format(self.s3_filename))
         except Exception as e:
             logger.exception(
                 "Something went wrong with upload of {}:{}"
                 .format(self.s3_filename, e)
             )
-            s3.abort_multipart_upload(Bucket=ZOOM_VIDEOS_BUCKET,
-                                      Key=self.s3_filename,
-                                      UploadId=mpu["UploadId"])
+            self.s3.abort_multipart_upload(
+                Bucket=ZOOM_VIDEOS_BUCKET,
+                Key=self.s3_filename,
+                UploadId=mpu["UploadId"]
+            )
+            raise
 
         if self.file_extension == "mp4":
             if not self.valid_mp4_file:


### PR DESCRIPTION
Overall about a 40% reduction in runtime.

Tested with 3 sets of files:

5.8 GB set of files
w/o multithreading - 301s
with multithreading - 200s

7.4 GB set of files
w/o multithreading - 455s
with multithreading - 252s

16.2 GB set of files (largest I could find in our Zoom account)
w/o multithreading - timed out after 900s (15 minutes) max runtime limit for lambdas
with multithreading - 529s

Memory usage increased for all cases from about 100MB to 150-160MB.