### PR TITLE
allow_multiple_ingests flag, invoke exec.on-demand-ingest task

### DIFF
--- a/docs/download-queue-message-example.json
+++ b/docs/download-queue-message-example.json
@@ -27,5 +27,8 @@
   ],
   // webhook function's aws request id
   "correlation_id": "cab436d8-64bc-11ea-bc55-0242ac130003",
-  "received_time": "2020-03-12T22:40:00Z"
+  "received_time": "2020-03-12T22:40:00Z",
+  // optional fields
+  "on_demand_series_id": "2020019999",
+  "allow_multiple_ingests": true
 }

--- a/docs/upload-queue-message-example.json
+++ b/docs/upload-queue-message-example.json
@@ -17,6 +17,8 @@
           "shared_screen_with_speaker_view": [
               "123456789/1584045816/000-shared_screen_with_speaker_view.mp4"
           ]
-      }
+      },
+      // optional field
+      "allow_multiple_ingests": true
   }
 }

--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -364,6 +364,10 @@ class Download:
                 "correlation_id": self.data["correlation_id"],
                 "s3_filenames": s3_filenames
             }
+
+            if "allow_multiple_ingests" in self.data:
+                self._upload_message["allow_multiple_ingests"] = self.data["allow_multiple_ingests"]
+
         return self._upload_message
 
     def upload_to_s3(self):

--- a/functions/zoom-on-demand.py
+++ b/functions/zoom-on-demand.py
@@ -112,8 +112,11 @@ def handler(event, context):
     # series id is an optional param. if not present the download function will
     # attempt to determine the series id by matching the recording times against
     # it's known schedule as usual.
-    if "oc_series_id" in body:
+    if "oc_series_id" in body and body["oc_series_id"]:
         webhook_data["payload"]["on_demand_series_id"] = body["oc_series_id"]
+
+    if "allow_multiple_ingests" in body:
+        webhook_data["payload"]["allow_multiple_ingests"] = body["allow_multiple_ingests"]
 
     logger.info({"webhook_data": webhook_data})
     try:
@@ -127,8 +130,8 @@ def handler(event, context):
     except Exception as e:
         err_msg = str(e)
         logger.exception(
-            "Something went wrong calling the webook: {}".format(err_msg)
+            "Something went wrong calling the webhook: {}".format(err_msg)
         )
-        return resp(500, err_msg);
+        return resp(500, err_msg)
 
     return resp(200, "Ingest accepted")

--- a/functions/zoom-webhook.py
+++ b/functions/zoom-webhook.py
@@ -174,6 +174,11 @@ def construct_sqs_message(payload, context, zoom_event):
                 timezone(LOCAL_TIME_ZONE).localize(datetime.today()),
                 TIMESTAMP_FORMAT)
 
+    if "allow_multiple_ingests" in payload:
+        allow_multiple_ingests = payload["allow_multiple_ingests"]
+    else:
+        allow_multiple_ingests = False
+
     recording_files = []
     for file in payload["object"]["recording_files"]:
         if file["file_type"].lower() == "mp4":
@@ -194,6 +199,7 @@ def construct_sqs_message(payload, context, zoom_event):
         "duration": payload["object"]["duration"],
         "host_id": payload["object"]["host_id"],
         "recording_files": recording_files,
+        "allow_multiple_ingests": allow_multiple_ingests,
         "correlation_id": context.aws_request_id,
         "received_time": now
     }

--- a/template.yml
+++ b/template.yml
@@ -256,6 +256,7 @@ Resources:
       RequestParameters:
         method.request.querystring.uuid: true
         method.request.querystring.oc_series_id: false
+        method.request.querystring.allow_multiple_ingests: false
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,8 @@ def webhook_payload():
                     ]
                 }
             },
-            "event": "recording.completed"
+            "event": "recording.completed",
+            "allow_multiple_ingests": False
         }
 
         if payload_extras is not None:
@@ -101,7 +102,8 @@ def sqs_message_from_webhook_payload(webhook_payload, aws_request_id):
             "host_id": payload_obj["host_id"],
             "recording_files": payload_obj["recording_files"],
             "received_time": frozen_time,
-            "correlation_id": aws_request_id
+            "correlation_id": aws_request_id,
+            "allow_multiple_ingests": False
         }
 
         if zoom_event == "recording.completed":


### PR DESCRIPTION
Add a field to the on demand ingest request (/ingest endpoint) that allows multiple ingests by generating a random mpid (in the uploader lambda) rather than a mpid based on the recording uuid.

Add a exec.on-demand-ingest task to conveniently invoke the /ingest endpoint.