### PR TITLE
fix ffprobe and extract file metadata

### DIFF
--- a/docs/upload-queue-message-example.json
+++ b/docs/upload-queue-message-example.json
@@ -13,10 +13,23 @@
       "webhook_received_time": "2020-03-13T00:34:12Z",
       // webhook function's aws request id
       "correlation_id": "cab436d8-64bc-11ea-bc55-0242ac130003",
-      "s3_filenames": {
-          "shared_screen_with_speaker_view": [
-              "123456789/1584045816/000-shared_screen_with_speaker_view.mp4"
-          ]
+      "s3_files": {
+          "shared_screen_with_speaker_view": {
+            "segments": [
+                {
+                    "filename": "123456789/1584045816/000-shared_screen_with_speaker_view.mp4",
+                    "recording_start": "2020-06-09T13:43:30Z",
+                    "recording_end": "2020-06-09T14:07:26Z",
+                    "ffprobe_bytes": 12345678,
+                    "ffprobe_seconds": 500.4
+                }
+            ],
+            "view_bytes": 12345678,
+            "view_seconds": 500.4
+        },
+        "total_file_bytes": 12345678,
+        "total_file_seconds": 500.4,
+        "total_segment_seconds": 500.4
       },
       // optional field
       "allow_multiple_ingests": true

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -230,7 +230,12 @@ class Upload:
 
     @property
     def s3_filenames(self):
-        return self.data["s3_filenames"]
+        if not hasattr(self, "_s3_filenames"):
+            self._s3_filenames = {}
+            for view, file in self.data["s3_files"].items():
+                self._s3_filenames[view] = [data["filename"] for data in file["segments"]]
+
+        return self._s3_filenames
 
     @property
     def workflow_id(self):


### PR DESCRIPTION
Goal here was to log some useful file metadata (size and duration) in the uploader so we can have some metrics for what is ingested into opencast.
While working on that, I realized that we weren't calling the method that runs ffprobe.
Fixed ffprobe and added a lot of file metadata to the uploader message.

Tested with the 16.4 GB set of files to make sure we weren't taking a large hit in terms of runtime and the downloader lambda completed in 8 minutes 39 seconds so it seems ok.