### PR TITLE
Bug fix: infinite recursion when recording is already ingested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+.env*
 dist/
 *.zip
 __pycache__
@@ -6,3 +6,8 @@ __pycache__
 .tox/
 outfile.txt
 .coverage
+venv/
+.idea/
+.gitconfig
+.ipynb*
+.vscode*

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -171,7 +171,6 @@ class Upload:
             # regardless of the allow_multiple_ingests flag
             mpid = str(UUID(md5(self.meeting_uuid.encode()).hexdigest()))
             if self.already_ingested(mpid):
-                mpid = None
                 if self.data["allow_multiple_ingests"]:
                     # random uuid
                     mpid = str(uuid4())
@@ -181,8 +180,9 @@ class Upload:
                 else:
                     logger.warning(
                         "Episode with deterministic mediapackage id"
-                        f" {self.mediapackage_id} already ingested"
+                        f" {mpid} already ingested"
                     )
+                    mpid = None
             else:
                 logger.info(
                     f"Created mediapackage id {mpid} "


### PR DESCRIPTION
Bug fix. The mediapackage_id function called itself in order to print out the mediapackage_id when a recording was already ingested and allow_multiple_ingests was false.

Also added unit tests.