### PR TITLE
filter false starts based on ffprobe duration data

### DIFF
--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -228,22 +228,54 @@ class Upload:
 
     @property
     def s3_filenames(self):
+        """
+        Pulls out the s3 filenames grouped by view type.
+
+        This is also the point where we need to filter out any
+        segments that are less than our MINIMUM_DURATION value. This is
+        tricky because the data is grouped by view instead of segment.
+
+        Basically we want to correctly handle a situation like this:
+
+            speaker view:
+              - foo/bar/000-speaker_view.mp4 (1m)
+              - foo/bar/001-speaker_view.mp4 (5m)
+              - foo/bar/002-speaker_view.mp4 (2h)
+
+            shared screen:
+              - foo/bar/001-shared_screen.mp4 (5m)
+              - foo/bar/002-shared_screen.mp4 (2h)
+
+        Here we have 3 segments of lenght 1m, 5m and 2h. However, the first
+        segment is only present in the "speaker" view. So we can't simply throw
+        away the first file from each view; we have to make sure it's from the
+        "000" segment.
+
+        :return: [description]
+        :rtype: [type]
+        """
+
         if not hasattr(self, "_s3_filenames"):
             self._s3_filenames = {}
-            for view, file_info in self.data["s3_files"].items():
-                segments = file_info["segments"]
+            # the s3_files dict is keyed on view type, e.g. gallery, speaker, etc
 
-                # skip false starts
-                if segments[0]["ffprobe_seconds"] < MINIMUM_DURATION * 60:
-                    # first segment for each view might not be the overall
-                    # first segment, need to check
-                    filename = segments[0]["filename"]
-                    segment_no = int(filename.split("/")[-1].split("-")[0])
-                    if segment_no == 0:
-                        segments = segments[1:]
+            # In this loop we're going to check the first file (segment) of each view.
+            # If it's < our MINIMUM_DURATION value
+            for view, file_info in self.data["s3_files"].items():
+
+                segment_files = file_info["segments"]
+
+                # check the duration of the first file in this view
+                too_short = segment_files[0]["ffprobe_seconds"] < (MINIMUM_DURATION * 60);
+
+                # check if this is part of the first segment
+                is_first_segment = segment_files[0]["segment_num"] == 0
+
+                if too_short and is_first_segment:
+                    segment_files = segment_files[1:]
 
                 self._s3_filenames[view] = [
-                    segment["filename"] for segment in segments
+                    file["filename"] for file in segment_files
                 ]
 
         return self._s3_filenames
@@ -480,4 +512,3 @@ class FileParamGenerator(object):
             raise RuntimeError("Unable to find a presenter view")
 
         return self._params
-

--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -235,7 +235,12 @@ class Upload:
 
                 # skip false starts
                 if segments[0]["ffprobe_seconds"] < MINIMUM_DURATION * 60:
-                    segments = segments[1:]
+                    # first segment for each view might not be the overall
+                    # first segment, need to check
+                    filename = segments[0]["filename"]
+                    segment_no = int(filename.split("/")[-1].split("-")[0])
+                    if segment_no == 0:
+                        segments = segments[1:]
 
                 self._s3_filenames[view] = [
                     segment["filename"] for segment in segments

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -521,7 +521,7 @@ def test_recording_files(download):
             {
                 "recording_start": "2020-03-31T12:00:00Z",
                 "recording_end": "2020-03-31T11:00:00Z",
-                "recording_type":"foo"
+                "recording_type": "foo"
             },
             {
                 "recording_start": "2020-03-31T12:00:00Z",
@@ -554,27 +554,6 @@ def test_recording_files_multi_set(download):
     assert len(zoom_files) == 5
     assert sum(1 for x in zoom_files if x._track_set == 1) == 3
 
-def test_recording_files_multi_set_false_start(download):
-    test_data = [
-        # This set is at the beginning and too short of a duration
-        # so should get ignored
-        ("2020-03-31T12:00:00Z", "2020-03-31T12:01:00Z", "foo"),
-        ("2020-03-31T12:00:00Z", "2020-03-31T12:01:00Z", "bar"),
-
-        ("2020-03-31T12:03:00Z", "2020-03-31T13:30:00Z", "foo"),
-        ("2020-03-31T12:03:00Z", "2020-03-31T13:30:00Z", "bar"),
-        ("2020-03-31T12:03:00Z", "2020-03-31T13:30:00Z", "baz"),
-    ]
-    download.data.update({
-        "recording_files": [
-            {"recording_start": x, "recording_end": y, "recording_type": z}
-            for x, y, z in test_data
-        ]
-    })
-
-    zoom_files = download.recording_files
-    assert len(zoom_files) == 3
-    assert sum(1 for x in zoom_files if x._track_set == 1) == 3
 
 @pytest.fixture
 def zoomfile(mocker):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -533,7 +533,7 @@ def test_recording_files(download):
 
     zoom_files = download.recording_files
     assert len(zoom_files) == 2
-    assert all(x._track_set == 0 for x in zoom_files)
+    assert all(x.segment_num == 0 for x in zoom_files)
 
 def test_recording_files_multi_set(download):
     test_data = [
@@ -552,7 +552,7 @@ def test_recording_files_multi_set(download):
 
     zoom_files = download.recording_files
     assert len(zoom_files) == 5
-    assert sum(1 for x in zoom_files if x._track_set == 1) == 3
+    assert sum(1 for x in zoom_files if x.segment_num == 1) == 3
 
 
 @pytest.fixture
@@ -569,4 +569,3 @@ def test_zoom_filename_ext(mocker, zoomfile):
     ]:
         zoomfile._zoom_filename = filename
         assert zoomfile.file_extension == expected
-

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -202,7 +202,8 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-speaker_view.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 0
                     }
                 ]
             },
@@ -210,7 +211,8 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-shared_screen.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 0
                     }
                 ]
             }
@@ -223,11 +225,13 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-speaker_view.mp4",
-                        "ffprobe_seconds": 5
+                        "ffprobe_seconds": 5,
+                        "segment_num": 0
                     },
                     {
                         "filename": "a/b/001-speaker_view.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 1
                     }
                 ]
             },
@@ -235,11 +239,13 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-shared_screen.mp4",
-                        "ffprobe_seconds": 5
+                        "ffprobe_seconds": 5,
+                        "segment_num": 0
                     },
                     {
                         "filename": "a/b/001-shared_screen.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 1
                     }
                 ]
             }
@@ -252,11 +258,13 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-speaker_view.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 0
                     },
                     {
                         "filename": "a/b/001-speaker_view.mp4",
-                        "ffprobe_seconds": 5
+                        "ffprobe_seconds": 5,
+                        "segment_num": 1
                     }
                 ]
             },
@@ -264,11 +272,13 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-shared_screen.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 0
                     },
                     {
                         "filename": "a/b/001-shared_screen.mp4",
-                        "ffprobe_seconds": 5
+                        "ffprobe_seconds": 5,
+                        "segment_num": 1
                     }
                 ]
             }
@@ -281,15 +291,18 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/000-speaker_view.mp4",
-                        "ffprobe_seconds": 5
+                        "ffprobe_seconds": 5,
+                        "segment_num": 0
                     },
                     {
                         "filename": "a/b/001-speaker_view.mp4",
-                        "ffprobe_seconds": 10
+                        "ffprobe_seconds": 10,
+                        "segment_num": 1
                     },
                     {
                         "filename": "a/b/002-speaker_view.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 2
                     }
                 ]
             },
@@ -297,11 +310,13 @@ def test_s3_filename_filter_false_start():
                 "segments": [
                     {
                         "filename": "a/b/001-shared_screen.mp4",
-                        "ffprobe_seconds": 10
+                        "ffprobe_seconds": 10,
+                        "segment_num": 1
                     },
                     {
                         "filename": "a/b/002-shared_screen.mp4",
-                        "ffprobe_seconds": 500
+                        "ffprobe_seconds": 500,
+                        "segment_num": 2
                     }
                 ]
             }

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -192,6 +192,64 @@ def test_get_current_upload_count(mocker):
     assert uploader.get_current_upload_count() == None
 
 
+def test_s3_filename_filter_false_start():
+    # entire meetings < MINIMUM_DURATION should have been filtered out
+    # in the downloader code so I don't test that case here
+
+    single_file = {
+        "s3_files": {
+            "speaker_view": {
+                "segments": [
+                    {
+                        "filename": "000.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            }
+        }
+    }
+
+    false_start = {
+        "s3_files": {
+            "speaker_view": {
+                "segments": [
+                    {
+                        "filename": "000.mp4",
+                        "ffprobe_seconds": 5
+                    },
+                    {
+                        "filename": "001.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            }
+        }
+    }
+
+    false_end = {
+        "s3_files": {
+            "speaker_view": {
+                "segments": [
+                    {
+                        "filename": "000.mp4",
+                        "ffprobe_seconds": 500
+                    },
+                    {
+                        "filename": "001.mp4",
+                        "ffprobe_seconds": 5
+                    }
+                ]
+            }
+        }
+    }
+
+    cases = [(single_file, 1), (false_start, 1), (false_end, 2)]
+
+    for data, expected in cases:
+        upload = uploader.Upload(data)
+        assert (len(upload.s3_filenames["speaker_view"]) == expected)
+
+
 def test_file_param_generator():
     # each `cases` item is a list containing two iterables
     # - first element in list gets turned into the s3_filenames data

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -201,7 +201,15 @@ def test_s3_filename_filter_false_start():
             "speaker_view": {
                 "segments": [
                     {
-                        "filename": "000.mp4",
+                        "filename": "a/b/000-speaker_view.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            },
+            "screen_share": {
+                "segments": [
+                    {
+                        "filename": "a/b/000-shared_screen.mp4",
                         "ffprobe_seconds": 500
                     }
                 ]
@@ -214,11 +222,23 @@ def test_s3_filename_filter_false_start():
             "speaker_view": {
                 "segments": [
                     {
-                        "filename": "000.mp4",
+                        "filename": "a/b/000-speaker_view.mp4",
                         "ffprobe_seconds": 5
                     },
                     {
-                        "filename": "001.mp4",
+                        "filename": "a/b/001-speaker_view.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            },
+             "screen_share": {
+                "segments": [
+                    {
+                        "filename": "a/b/000-shared_screen.mp4",
+                        "ffprobe_seconds": 5
+                    },
+                    {
+                        "filename": "a/b/001-shared_screen.mp4",
                         "ffprobe_seconds": 500
                     }
                 ]
@@ -231,11 +251,23 @@ def test_s3_filename_filter_false_start():
             "speaker_view": {
                 "segments": [
                     {
-                        "filename": "000.mp4",
+                        "filename": "a/b/000-speaker_view.mp4",
                         "ffprobe_seconds": 500
                     },
                     {
-                        "filename": "001.mp4",
+                        "filename": "a/b/001-speaker_view.mp4",
+                        "ffprobe_seconds": 5
+                    }
+                ]
+            },
+            "screen_share": {
+                "segments": [
+                    {
+                        "filename": "a/b/000-shared_screen.mp4",
+                        "ffprobe_seconds": 500
+                    },
+                    {
+                        "filename": "a/b/001-shared_screen.mp4",
                         "ffprobe_seconds": 5
                     }
                 ]
@@ -243,11 +275,52 @@ def test_s3_filename_filter_false_start():
         }
     }
 
-    cases = [(single_file, 1), (false_start, 1), (false_end, 2)]
+    segment_mismatch = {
+        "s3_files": {
+            "speaker_view": {
+                "segments": [
+                    {
+                        "filename": "a/b/000-speaker_view.mp4",
+                        "ffprobe_seconds": 5
+                    },
+                    {
+                        "filename": "a/b/001-speaker_view.mp4",
+                        "ffprobe_seconds": 10
+                    },
+                    {
+                        "filename": "a/b/002-speaker_view.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            },
+            "screen_share": {
+                "segments": [
+                    {
+                        "filename": "a/b/001-shared_screen.mp4",
+                        "ffprobe_seconds": 10
+                    },
+                    {
+                        "filename": "a/b/002-shared_screen.mp4",
+                        "ffprobe_seconds": 500
+                    }
+                ]
+            }
+        }
+    }
 
-    for data, expected in cases:
+    cases = [
+        (single_file, 1, 1),
+        (false_start, 1, 1),
+        (false_end, 2, 2),
+        (segment_mismatch, 2, 2)
+    ]
+
+    for data, expected_speaker, expected_screen_share in cases:
         upload = uploader.Upload(data)
-        assert (len(upload.s3_filenames["speaker_view"]) == expected)
+        assert (len(upload.s3_filenames["speaker_view"]) == expected_speaker)
+        assert (
+            len(upload.s3_filenames["screen_share"]) == expected_screen_share
+        )
 
 
 def test_file_param_generator():


### PR DESCRIPTION
Commentary on a better place to do the filtering welcome. It's a little difficult because we cannot filter before we transfer the files to S3 (since we need the ffprobe data) but after we transfer the files to S3 the files are organized by view not segment in order to make the filtering by view easy in the uploader.