### PR TITLE
bug fix - Sneaky file param generator bug.

### DIFF
--- a/functions/zoom-uploader.py
+++ b/functions/zoom-uploader.py
@@ -445,7 +445,7 @@ class FileParamGenerator(object):
 
     def __init__(self, s3_filenames):
         self.s3_filenames = s3_filenames
-        self._used_views = []
+        self._used_views = set()
         self._params = []
         # whatever the max length of any view's list of files is the number
         # of sets of files we're dealing with. When hosts stop/start a meeting
@@ -522,7 +522,7 @@ class FileParamGenerator(object):
                     ),
                 ]
             )
-            self._used_views.append(view)
+        self._used_views.add(view)
 
     def _generate_presigned_url(self, s3_filename):
         logger.info(

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -706,6 +706,36 @@ def test_file_param_generator_multi_set():
                 ("mediaUri", (None, "signed-screen-001.mp4")),
             ],
         ],
+        # Make sure having 3 segments doesn't break the file param generator!
+        [
+            {
+                "active_speaker": [
+                    "speaker-000.mp4",
+                    "speaker-001.mp4",
+                    "speaker-002.mp4",
+                ],
+                "shared_screen_with_speaker_view": [
+                    "screen-000.mp4",
+                    "screen-001.mp4",
+                    "screen-002.mp4",
+                ],
+            },
+            # params should include both files for both views
+            [
+                ("flavor", (None, "multipart/chunked+source")),
+                ("mediaUri", (None, "signed-speaker-000.mp4")),
+                ("flavor", (None, "multipart/chunked+source")),
+                ("mediaUri", (None, "signed-speaker-001.mp4")),
+                ("flavor", (None, "multipart/chunked+source")),
+                ("mediaUri", (None, "signed-speaker-002.mp4")),
+                ("flavor", (None, "presentation/chunked+source")),
+                ("mediaUri", (None, "signed-screen-000.mp4")),
+                ("flavor", (None, "presentation/chunked+source")),
+                ("mediaUri", (None, "signed-screen-001.mp4")),
+                ("flavor", (None, "presentation/chunked+source")),
+                ("mediaUri", (None, "signed-screen-002.mp4")),
+            ],
+        ],
     ]
     for incoming, expected in cases:
         fpg = uploader.FileParamGenerator(s3_filenames=incoming)


### PR DESCRIPTION
Really sneaky bug. Thank you @rute-santos for the find.

Because `self._used_views.append(view)` was indented and inside the s3_filenames loop, and also because `self._used_views` was a list and not a set. The `self._used_views` contained as many items as the number of files, not the number of views.

For example, ingesting a 3 segment recording with the views "active_speaker" and "shared_screen_with_speaker" results in the `self._used_views` list `["active_speaker", "active_speaker", "active_speaker"]`.

When the check `if len(self._used_views) >= len(self.FLAVORS):` is done when attempting to add "shared_screen_with_speaker" as the secondary view, the length of `self._used_views` is 3, which is equal to the number of flavors, and the secondary view is skipped.