### PR TITLE
b/zip 70 schedule day parsing

### DIFF
--- a/functions/utils/gsheets.py
+++ b/functions/utils/gsheets.py
@@ -130,7 +130,9 @@ class GSheet:
 
 
 def schedule_json_to_dynamo(
-    dynamo_table_name, json_file=None, schedule_data=None
+    dynamo_table_name,
+    json_file=None,
+    schedule_data=None,
 ):
     if json_file is not None:
         with open(json_file, "r") as file:
@@ -141,9 +143,8 @@ def schedule_json_to_dynamo(
                 return
     elif schedule_data is None:
         raise Exception(
-            "{} called with no json_file or schedule_data args".format(
-                sys._getframe().f_code.co_name
-            )
+            f"{sys._getframe().f_code.co_name} called with "
+            "no json_file or schedule_data args"
         )
 
     try:
@@ -237,13 +238,7 @@ def schedule_csv_to_dynamo(dynamo_table_name, filepath):
 
         # value might look like "MW", "TR" or "MWF"
         days_value = row["day"].strip()
-        if len(days_value) > 1 and " " not in days_value:
-            days = list(days_value)
-        else:
-            split_by = " "
-            if "," in days_value:
-                split_by = ","
-            days = [day.strip() for day in days_value.split(split_by)]
+        days = list(days_value.replace(",", "").replace(" ", ""))
 
         for day in days:
             if day not in valid_days:

--- a/tests/input/schedule1.csv
+++ b/tests/input/schedule1.csv
@@ -5,5 +5,6 @@ CSCI E-61,Lecture,T,9:15,https://harvard.zoom.us/j/555555555,https://matterhorn.
 CSCI E-61,Staff Meeting,W,12:00,https://harvard.zoom.us/j/555555555,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/61616,Producer2
 CSCI E-61,Section,R,20:00,https://harvard.zoom.us/j/555555555,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/61616,Producer2
 CSCI E-61,Lecture,F,13:15,https://harvard.zoom.us/j/555555555,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/61616,Producer2
+ECON E-10A,Lecture,"MT R",11:00,https://harvard.zoom.us/j/876876876,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/87678,Producer3
 MATH E-55,Lecture,"T,R",14:30,https://harvard.zoom.us/j/123123123,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/55155,Producer2
 STAT S-100,Section,"S, U",18:30,https://harvard.zoom.us/j/100100100,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/10010,Producer2

--- a/tests/input/schedule1.csv
+++ b/tests/input/schedule1.csv
@@ -6,5 +6,6 @@ CSCI E-61,Staff Meeting,W,12:00,https://harvard.zoom.us/j/555555555,https://matt
 CSCI E-61,Section,R,20:00,https://harvard.zoom.us/j/555555555,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/61616,Producer2
 CSCI E-61,Lecture,F,13:15,https://harvard.zoom.us/j/555555555,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/61616,Producer2
 ECON E-10A,Lecture,"MT R",11:00,https://harvard.zoom.us/j/876876876,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/87678,Producer3
+ECON E-20A,Lecture,"TRF",13:00,https://harvard.zoom.us/j/200200200,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/20020,Producer3
 MATH E-55,Lecture,"T,R",14:30,https://harvard.zoom.us/j/123123123,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/55155,Producer2
 STAT S-100,Section,"S, U",18:30,https://harvard.zoom.us/j/100100100,https://matterhorn.dce.harvard.edu/engage/ui/index.html#/2021/01/10010,Producer2

--- a/tests/test_utils_gsheets.py
+++ b/tests/test_utils_gsheets.py
@@ -40,6 +40,16 @@ def test_schedule_successful_parsing(mocker):
             "opencast_series_id": "20210161616",
             "zoom_series_id": "555555555",
         },
+        "876876876": {
+            "course_code": "ECON E-10A",
+            "events": [
+                {"day": "M", "time": "11:00", "title": "Lecture"},
+                {"day": "T", "time": "11:00", "title": "Lecture"},
+                {"day": "R", "time": "11:00", "title": "Lecture"},
+            ],
+            "opencast_series_id": "20210187678",
+            "zoom_series_id": "876876876",
+        },
         "123123123": {
             "course_code": "MATH E-55",
             "events": [

--- a/tests/test_utils_gsheets.py
+++ b/tests/test_utils_gsheets.py
@@ -50,6 +50,16 @@ def test_schedule_successful_parsing(mocker):
             "opencast_series_id": "20210187678",
             "zoom_series_id": "876876876",
         },
+        "200200200": {
+            "course_code": "ECON E-20A",
+            "events": [
+                {"day": "T", "time": "13:00", "title": "Lecture"},
+                {"day": "R", "time": "13:00", "title": "Lecture"},
+                {"day": "F", "time": "13:00", "title": "Lecture"},
+            ],
+            "opencast_series_id": "20210120020",
+            "zoom_series_id": "200200200",
+        },
         "123123123": {
             "course_code": "MATH E-55",
             "events": [


### PR DESCRIPTION
Fix bug where days formatted with mixed spaces. For example: "MT R" were not handled correctly.

See ZIP-70 and PSUPP-3343