### PR TITLE
f/zip 68 multiple gsheets sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ state of the CloudFormation stack and the Lambda functions run `invoke stack.sta
 
 #### Google Sheets API Auth
 
-1. Fill in Google Sheets environment variables `GSHEETS_DOC_ID` and `GSHEETS_SHEET_NAME`
+1. Fill in Google Sheets environment variables `GSHEETS_DOC_ID` and `GSHEETS_SHEET_NAMES`
 
 Since these credentials are shared within an AWS account, the following setup
 only needs to be done once per AWS account:

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -76,7 +76,7 @@ stack_props = {
         "https://github.com/harvard-dce/zoom-recording-ingester.git"
     ),
     "gsheets_doc_id": getenv("GSHEETS_DOC_ID"),
-    "gsheets_sheet_name": getenv("GSHEETS_SHEET_NAME"),
+    "gsheets_sheet_names": getenv("GSHEETS_SHEET_NAMES"),
     "slack_signing_secret": getenv("SLACK_SIGNING_SECRET", required=False),
     "slack_zip_channel": getenv("SLACK_ZIP_CHANNEL", required=False),
     "slack_api_token": getenv("SLACK_API_TOKEN", required=False),

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -54,7 +54,7 @@ class ZipStack(core.Stack):
         uploader_event_rate,
         project_git_url,
         gsheets_doc_id,
-        gsheets_sheet_name,
+        gsheets_sheet_names,
         slack_signing_secret,
         slack_zip_channel,
         slack_allowed_groups,
@@ -91,7 +91,7 @@ class ZipStack(core.Stack):
             environment={
                 "CLASS_SCHEDULE_TABLE": schedule.table.table_name,
                 "GSHEETS_DOC_ID": gsheets_doc_id,
-                "GSHEETS_SHEET_NAME": gsheets_sheet_name,
+                "GSHEETS_SHEET_NAMES": gsheets_sheet_names,
             },
         )
         schedule_update.function.add_to_role_policy(

--- a/example.env
+++ b/example.env
@@ -83,8 +83,8 @@ INGEST_ALLOWED_IPS=
 # Google sheets
 # The document id
 GSHEETS_DOC_ID =
-# The name of the actual tab to download as a csv
-GSHEETS_SHEET_NAME=
+# Comma delimited list of the names of tabs to download as a csv
+GSHEETS_SHEET_NAMES=
 
 # Create a custom Slack app at https://api.slack.com/
 # Creating an app generates a signing secret

--- a/functions/schedule-update.py
+++ b/functions/schedule-update.py
@@ -17,7 +17,7 @@ def handler(event, context):
     logger.info(f"Get Google Sheet doc ID '{GSHEETS_DOC_ID}'")
     doc = GSheet(GSHEETS_DOC_ID)
 
-    sheets = GSHEETS_SHEET_NAMES.split(",")
+    sheets = [x.strip() for x in GSHEETS_SHEET_NAMES.split(",") if x]
     for sheet in sheets:
         logger.info(f"Import data from '{sheet}' sheet")
         doc.import_to_dynamo(sheet)

--- a/functions/schedule-update.py
+++ b/functions/schedule-update.py
@@ -4,7 +4,7 @@ from utils import setup_logging, GSheet
 
 
 GSHEETS_DOC_ID = env("GSHEETS_DOC_ID")
-GSHEETS_SHEET_NAME = env("GSHEETS_SHEET_NAME")
+GSHEETS_SHEET_NAMES = env("GSHEETS_SHEET_NAMES")
 
 logger = logging.getLogger()
 
@@ -15,8 +15,11 @@ def handler(event, context):
     Load google sheet, parse, and import into dynamoDB.
     """
     logger.info(f"Get Google Sheet doc ID '{GSHEETS_DOC_ID}'")
-    sheet = GSheet(GSHEETS_DOC_ID)
-    logger.info(f"Import data from '{GSHEETS_SHEET_NAME}' sheet")
-    sheet.import_to_dynamo(GSHEETS_SHEET_NAME)
+    doc = GSheet(GSHEETS_DOC_ID)
+
+    sheets = GSHEETS_SHEET_NAMES.split(",")
+    for sheet in sheets:
+        logger.info(f"Import data from '{sheet}' sheet")
+        doc.import_to_dynamo(sheet)
 
     return {"statusCode": 200, "headers": {}, "body": "Success"}

--- a/functions/utils/gsheets.py
+++ b/functions/utils/gsheets.py
@@ -91,7 +91,7 @@ class GSheetsAuth:
 
 
 class GSheet:
-    def __init__(self, spreadsheet_id, in_lambda=False):
+    def __init__(self, spreadsheet_id):
         self.spreadsheet_id = spreadsheet_id
         auth = GSheetsAuth()
         auth.load_from_ssm()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,13 @@
+import site
+from os.path import dirname, join
+from importlib import import_module
+
+site.addsitedir(join(dirname(dirname(__file__)), "functions"))
+
+webhook = import_module("zoom-webhook")
+downloader = import_module("zoom-downloader")
+uploader = import_module("zoom-uploader")
+
+
+def test_status():
+    pass

--- a/tests/test_schedule_update.py
+++ b/tests/test_schedule_update.py
@@ -14,6 +14,7 @@ def test_handler(mocker, handler):
     cases = [
         ("ZIP", ["ZIP"]),
         ("Sheet1,Sheet2", ["Sheet1", "Sheet2"]),
+        ("foo , bar,, baz", ["foo", "bar", "baz"]),
     ]
 
     for sheet_names, expected in cases:

--- a/tests/test_schedule_update.py
+++ b/tests/test_schedule_update.py
@@ -1,0 +1,29 @@
+import site
+from os.path import dirname, join
+from importlib import import_module
+
+site.addsitedir(join(dirname(dirname(__file__)), "functions"))
+
+schedule_update = import_module("schedule-update")
+
+
+def test_handler(mocker, handler):
+    schedule_update.GSHEETS_DOC_ID = "mock_doc_id"
+    mock_gsheets = mocker.patch.object(schedule_update, "GSheet")
+
+    cases = [
+        ("ZIP", ["ZIP"]),
+        ("Sheet1,Sheet2", ["Sheet1", "Sheet2"]),
+    ]
+
+    for sheet_names, expected in cases:
+        schedule_update.GSHEETS_SHEET_NAMES = sheet_names
+
+        res = handler(schedule_update, {})
+        assert res["statusCode"] == 200
+
+        calls = [mocker.call(sheet) for sheet in expected]
+
+        mock_gsheets.return_value.import_to_dynamo.assert_has_calls(
+            calls=calls
+        )


### PR DESCRIPTION
Change env var GSHEETS_SHEET_NAME to GSHEET_SHEET_NAMES and accept a comma delimited list of gsheets sheet names (tabs within a gsheets document.)

Purpose to allow QA to have a separate tab in the production google sheets schedule document.