### PR TITLE
ZIP-89: remove zoom api call to get `host_name` value

### DIFF
--- a/docs/queue-message-example.md
+++ b/docs/queue-message-example.md
@@ -51,7 +51,6 @@
       // meeting room id
       "zoom_series_id": 123456789,
       "opencast_series_id": "20190199999",
-      "host_name": "Foo Bar",
       "topic": "Special Lecture",
       "created": "2020-03-12T20:43:36Z",
       "created_local": "2020-03-12T16:43:36Z",

--- a/functions/zoom-downloader.py
+++ b/functions/zoom-downloader.py
@@ -5,7 +5,6 @@ from os import getenv as env
 from pathlib import Path
 from utils import (
     setup_logging,
-    zoom_api_request,
     TIMESTAMP_FORMAT,
     retrieve_schedule,
     schedule_match,
@@ -162,14 +161,6 @@ class Download:
         self.title = "Lecture"  # default title
 
         logger.info({"download_message": self.download_message})
-
-    @property
-    def host_name(self):
-        if not hasattr(self, "_host_name"):
-            resp = zoom_api_request(f"users/{self.data['host_id']}").json()
-            logger.info({"Host details": resp})
-            self._host_name = f"{resp['first_name']} {resp['last_name']}"
-        return self._host_name
 
     @property
     def uuid(self):
@@ -335,7 +326,6 @@ class Download:
                 "zoom_series_id": self.data["zoom_series_id"],
                 "opencast_series_id": self.opencast_series_id,
                 "oc_title": self.title,
-                "host_name": self.host_name,
                 "topic": self.data["topic"],
                 "created": datetime.strftime(
                     self._created_utc, TIMESTAMP_FORMAT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ def upload_message(mocker):
             "uuid": "abcdefg1234==",
             "zoom_series_id": 123456789,
             "opencast_series_id": "20200299999",
-            "host_name": "Angela Amari",
             "topic": "TEST E-50",
             "created": "2020-03-09T23:19:20Z",
             "webhook_received_time": "2020-03-10T01:58:03Z",

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -486,11 +486,11 @@ class TestDownload(unittest.TestCase):
             new_callable=PropertyMock,
         )
 
-        self.mocker.patch.object(
-            downloader.Download,
-            "host_name",
-            "instructor",
-        )
+        # self.mocker.patch.object(
+        #     downloader.Download,
+        #     "host_name",
+        #     "instructor",
+        # )
 
         received_time = (
             datetime.strptime(FROZEN_TIME, TIMESTAMP_FORMAT)
@@ -518,7 +518,6 @@ class TestDownload(unittest.TestCase):
             "zoom_series_id": 123,
             "opencast_series_id": "mock_series_id",
             "oc_title": "Lecture",
-            "host_name": "instructor",
             "topic": "Statistics",
             "created": FROZEN_TIME_UTC,
             "created_local": FROZEN_TIME,


### PR DESCRIPTION
Trying to minimize the zoom api "scopes" required. This value is passed into the SQS message to the uploader but never used