### PR TITLE
ZIP-101 Fix exception in uploader when recording is too short

### DIFF
--- a/functions/utils/recording_events.py
+++ b/functions/utils/recording_events.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import boto3
 from botocore.exceptions import ClientError
 from os import getenv as env
@@ -235,4 +235,6 @@ def from_utc_to_timestamp(date_str):
 
 
 def from_timestamp_to_utc(ts):
-    return datetime.strftime(datetime.utcfromtimestamp(ts), TIMESTAMP_FORMAT)
+    return datetime.strftime(
+        datetime.fromtimestamp(int(ts), UTC), TIMESTAMP_FORMAT
+    )

--- a/functions/zoom_downloader.py
+++ b/functions/zoom_downloader.py
@@ -87,7 +87,12 @@ def handler(event, context):
         # this is checking for ~total~ duration of the recording as reported
         # by zoom in the webhook payload data. There is a separate check later
         # for the duration potentially different sets of files
-        if dl.duration >= MINIMUM_DURATION or dl_data["on_demand_ingest"]:
+        # ZIP-101: Removed the check for on-demand ingest:
+        # 'or dl_data["on_demand_ingest"]' because, if we want to allow
+        # on-demand ingests < minimum, we need to also allow the first segment
+        # to be < minimum and this is not true for all on-demand ingests so we
+        # need to add an explicit parameter for that.
+        if dl.duration >= MINIMUM_DURATION:
             if dl.oc_series_found(ignore_schedule, override_series_id):
                 set_pipeline_status(
                     dl_data["zip_id"],

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -756,7 +756,7 @@ def test_handler_duration_check(handler, mocker):
     assert mock_msg.delete.call_count == 1
 
 
-def test_ignore_duration_check_for_on_demand(handler, mocker):
+def test_do_not_ignore_duration_check_for_on_demand(handler, mocker):
     downloader.DOWNLOAD_MESSAGES_PER_INVOCATION = 1
     mocker.patch.object(downloader, "sqs", mocker.Mock())
     mocker.patch.object(
@@ -779,9 +779,8 @@ def test_ignore_duration_check_for_on_demand(handler, mocker):
     )
     handler(downloader, {})
 
-    # if we got here it means we passed the duration check
-    # should pass because the ingest is an on demand ingest
-    assert downloader.Download.oc_series_found.call_count == 1
+    # should not have gotten here past the duration check
+    assert downloader.Download.oc_series_found.call_count == 0
     assert mock_msg.delete.call_count == 1
 
 


### PR DESCRIPTION
Abort ingesting of short recording in downloader.
If we want to allow override when ingesting on-demand, we need to provide an explicit way to choose that.